### PR TITLE
Fixes #3 - Make context part of similarity, not global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 
 venv:
 	@echo "Checking virtualenv..."
-	@if [ ! -d "venv" ]; then \
+	if [ ! -d "venv" ]; then \
 		echo "Creating virtualenv..."; \
 		python3 -m venv venv; \
 		. venv/bin/activate; \
 		pip install --upgrade pip; \
-		pip install -r requirements.txt
+		pip install -r requirements.txt; \
 	fi
 
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pytest
 from searcharray.postings import SearchArray
+from searcharray.similarity import bm25_similarity
 from test_utils import w_scenarios
 
 
@@ -38,6 +39,22 @@ def test_doc_lengths(data):
     assert doc_lengths.shape == (100,)
     assert (doc_lengths == [4, 1, 2, 3] * 25).all()
     assert data.avg_doc_length == 2.5
+
+
+def test_sim_change_is_different(data):
+    bm25 = data.score("bar")
+    custom_bm25 = bm25_similarity(k1=10, b=0.01)
+    bm25_custom = data.score("bar", similarity=custom_bm25)
+    assert not np.isclose(bm25[bm25 > 0],
+                          bm25_custom[bm25_custom > 0]).any()
+
+
+def test_custom_sim_multiple_calls(data):
+    custom_bm25 = bm25_similarity(k1=10, b=0.01)
+    bm25_custom1 = data.score("bar", similarity=custom_bm25)
+    bm25_custom2 = data.score("bar", similarity=custom_bm25)
+    assert np.isclose(bm25_custom1,
+                      bm25_custom2).all()
 
 
 def test_default_score_matches_lucene(data):

--- a/test/test_similarity.py
+++ b/test/test_similarity.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from searcharray.similarity import bm25_similarity, ScoringContext
+from searcharray.similarity import bm25_similarity
 from test_utils import w_scenarios
 
 
@@ -36,10 +36,9 @@ lucene_bm25_scenarios = {
 @w_scenarios(lucene_bm25_scenarios)
 def test_bm25_similarity_matches_lucene(term_freqs, doc_freqs, doc_lens, avg_doc_len, num_docs, expected):
     default_bm25 = bm25_similarity(k1=1.2, b=0.75)
-    context = ScoringContext(num_docs=num_docs,
-                             doc_lens=arr(doc_lens),
-                             avg_doc_lens=avg_doc_len)
     bm25 = default_bm25(arr(term_freqs),
                         arr(doc_freqs),
-                        context)
+                        arr(doc_lens),
+                        avg_doc_len,
+                        num_docs)
     assert np.isclose(bm25, expected).all()

--- a/test/test_solr.py
+++ b/test/test_solr.py
@@ -5,7 +5,6 @@ from test_utils import w_scenarios
 import pandas as pd
 import numpy as np
 
-from searcharray.similarity import ScoringContext
 from searcharray.solr import parse_min_should_match, edismax
 from searcharray.postings import SearchArray
 
@@ -209,7 +208,8 @@ def test_edismax(frame, expected, params):
     assert np.allclose(scores, expected)
 
 
-def always_one_similarity(term_freqs: np.ndarray, doc_freqs: np.ndarray, context: ScoringContext) -> np.ndarray:
+def always_one_similarity(term_freqs: np.ndarray, doc_freqs: np.ndarray,
+                          doc_lens: np.ndarray, avg_doc_lens: int, num_docs: int) -> np.ndarray:
     term_freqs = term_freqs
     return term_freqs > 0
 


### PR DESCRIPTION
As part of perf optimizations, some repeated similarity calculations were part of scoring context. This broke cases where if the similarity changed, you might use information from old cached computations with old paramaters.

Having a global scoring context means that we have the problem of needing to detect if the similarity changed to correctly recalculate any working context. Of course if you switch back to the old similarity, you'll lose all that information.

It seems smarter to make context an optional / cacheable part of a similarity. Simplifying similarity interface, but allowing some similarities to be optimized if we want.

So this PR make context a part of BM25, but for now not part of other similarities. 