### PR TITLE
Fixes issue #8 with GCC/Clang-specific compiler intrinsics with MSVC/MS Windows

### DIFF
--- a/searcharray/roaringish/popcount.pyx
+++ b/searcharray/roaringish/popcount.pyx
@@ -15,14 +15,51 @@ import numpy as np
 cimport searcharray.roaringish.snp_ops
 from searcharray.roaringish.snp_ops cimport DTYPE_t
 
+cdef extern from *:
+    """
+    #if defined(_MSC_VER)
+        #include <intrin.h>
+        #pragma intrinsic(__popcnt64)
+        #pragma intrinsic(_BitScanForward64)
+        #pragma intrinsic(_BitScanReverse64)
 
-cdef extern from "stddef.h":
-    # Assuming size_t is available via stddef.h for the example's simplicity
-    # and portability, though it's not directly used here.
-    int __builtin_popcountll(unsigned long long x)
+        static int popcount(unsigned long long x) {
+            return __popcnt64(x);
+        }
 
-    int __builtin_ctzll(unsigned long long x)
-    int __builtin_clzll(unsigned long long x)
+        static int ctzll(unsigned long long x) {
+            unsigned long index;
+            if (x == 0) return 64;
+            _BitScanForward64(&index, x);
+            return index;
+        }
+
+        static int clzll(unsigned long long x) {
+            unsigned long index;
+            if (x == 0) return 64;
+            _BitScanReverse64(&index, x);
+            return 63 - index;
+        }
+
+    #else
+        static int popcount(unsigned long long x) {
+            return __builtin_popcountll(x);
+        }
+
+        static int ctzll(unsigned long long x) {
+            return __builtin_ctzll(x);
+        }
+
+        static int clzll(unsigned long long x) {
+            return __builtin_clzll(x);
+        }
+    #endif
+    """
+
+cdef extern from *:
+    int popcount(unsigned long long x)
+    int ctzll(unsigned long long x)
+    int clzll(unsigned long long x)
 
 
 # Include mach performance timer
@@ -37,7 +74,7 @@ cdef popcount64_arr(DTYPE_t[:] arr):
     cdef DTYPE_t* arr_ptr = &arr[0]
 
     for _ in range(arr.shape[0]):
-        result_ptr[0] = __builtin_popcountll(arr_ptr[0])
+        result_ptr[0] = popcount(arr_ptr[0])
         result_ptr += 1
         arr_ptr += 1
     return result
@@ -50,7 +87,7 @@ cdef ctz_arr(DTYPE_t[:] arr):
     cdef DTYPE_t* arr_ptr = &arr[0]
 
     for _ in range(arr.shape[0]):
-        result_ptr[0] = __builtin_ctzll(arr_ptr[0])
+        result_ptr[0] = ctzll(arr_ptr[0])
         result_ptr += 1
         arr_ptr += 1
     return result
@@ -63,7 +100,7 @@ cdef clz_arr(DTYPE_t[:] arr):
     cdef DTYPE_t* arr_ptr = &arr[0]
 
     for _ in range(arr.shape[0]):
-        result_ptr[0] = __builtin_clzll(arr_ptr[0])
+        result_ptr[0] = clzll(arr_ptr[0])
         result_ptr += 1
         arr_ptr += 1
     return result
@@ -74,7 +111,7 @@ cdef popcount64_arr_naive(DTYPE_t[:] arr):
     cdef int i = 0
 
     for i in range(arr.shape[0]):
-        result[i] = __builtin_popcountll(arr[i])
+        result[i] = popcount(arr[i])
     return result
 
 
@@ -100,7 +137,7 @@ cdef DTYPE_t _popcount_reduce_at(DTYPE_t[:] ids, DTYPE_t[:] payload,
             popcount_sum = 0
             merged_ids_ptr += 1
             merged_counts_ptr += 1
-        popcount_sum += __builtin_popcountll(payload_ptr[0])
+        popcount_sum += popcount(payload_ptr[0])
         last_id = ids_ptr[0]
         payload_ptr += 1
         ids_ptr += 1
@@ -187,14 +224,14 @@ cdef _popcount64_reduce(DTYPE_t[:] arr,
     for _ in range(arr.shape[0]):
         key = arr_ptr[0] >> key_shift
         if key == last_key:
-            popcounts_ptr[0] += __builtin_popcountll(arr_ptr[0] & value_mask)
+            popcounts_ptr[0] += popcount(arr_ptr[0] & value_mask)
         else:
             last_key = key
             popcounts_ptr += 1
             keys_ptr += 1
             # Init next key
             keys_ptr[0] = last_key
-            popcounts_ptr[0] = __builtin_popcountll(arr_ptr[0] & value_mask)
+            popcounts_ptr[0] = popcount(arr_ptr[0] & value_mask)
         arr_ptr += 1
     return keys, popcounts, (keys_ptr - &keys[0] + 1)
 
@@ -223,7 +260,7 @@ cdef _popcount64_reduce_nobranch(DTYPE_t[:] arr,
         key = arr_ptr[0] >> key_shift
         popcounts_ptr += (key != last_key)
         keys_ptr += (key != last_key)
-        popcounts_ptr[0] += __builtin_popcountll(arr_ptr[0] & value_mask)
+        popcounts_ptr[0] += popcount(arr_ptr[0] & value_mask)
         keys_ptr[0] = key
         last_key = key
         arr_ptr += 1

--- a/searcharray/roaringish/roaringish_ops.pyx
+++ b/searcharray/roaringish/roaringish_ops.pyx
@@ -23,10 +23,23 @@ from searcharray.roaringish.snp_ops cimport DTYPE_t
 cdef DTYPE_t ALL_BITS = 0xFFFFFFFFFFFFFFFF
 
 
-cdef extern from "stddef.h":
-    # Assuming size_t is available via stddef.h for the example's simplicity
-    # and portability, though it's not directly used here.
-    int __builtin_popcountll(unsigned long long x)
+cdef extern from *:
+    """
+    #if defined(_MSC_VER)
+        #include <intrin.h>
+        #pragma intrinsic(__popcnt64)
+        static int popcount(unsigned long long x) {
+            return __popcnt64(x);
+        }
+    #else
+        static int popcount(unsigned long long x) {
+            return __builtin_popcountll(x);
+        }
+    #endif
+    """
+
+cdef extern from *:
+    int popcount(unsigned long long x)
 
 
 cdef _payload_slice(DTYPE_t[:] arr,

--- a/searcharray/roaringish/roaringish_ops.pyx
+++ b/searcharray/roaringish/roaringish_ops.pyx
@@ -28,18 +28,19 @@ cdef extern from *:
     #if defined(_MSC_VER)
         #include <intrin.h>
         #pragma intrinsic(__popcnt64)
-        static int popcount(unsigned long long x) {
+        static int popcountll(unsigned long long x) {
             return __popcnt64(x);
         }
     #else
-        static int popcount(unsigned long long x) {
+        #include <stddef.h>
+        static int popcountll(unsigned long long x) {
             return __builtin_popcountll(x);
         }
     #endif
     """
 
 cdef extern from *:
-    int popcount(unsigned long long x)
+    int popcountll(unsigned long long x)
 
 
 cdef _payload_slice(DTYPE_t[:] arr,

--- a/searcharray/roaringish/spans.pyx
+++ b/searcharray/roaringish/spans.pyx
@@ -19,7 +19,7 @@ cdef extern from *:
         #pragma intrinsic(_BitScanForward64)
         #pragma intrinsic(_BitScanReverse64)
 
-        static int popcount(unsigned long long x) {
+        static int popcountll(unsigned long long x) {
             return __popcnt64(x);
         }
 
@@ -38,7 +38,8 @@ cdef extern from *:
         }
 
     #else
-        static int popcount(unsigned long long x) {
+        #include <stddef.h>
+        static int popcountll(unsigned long long x) {
             return __builtin_popcountll(x);
         }
 
@@ -53,7 +54,7 @@ cdef extern from *:
     """
 
 cdef extern from *:
-    int popcount(unsigned long long x)
+    int popcountll(unsigned long long x)
     int ctzll(unsigned long long x)
     int clzll(unsigned long long x)
 
@@ -108,11 +109,11 @@ cdef DTYPE_t _posn_mask(np.int64_t curr_posn):
 
 
 cdef DTYPE_t _num_terms(ActiveSpans* spans, DTYPE_t span_idx):
-    return popcount(spans[0].terms[span_idx])
+    return popcountll(spans[0].terms[span_idx])
 
 
 cdef DTYPE_t _num_posns(ActiveSpans* spans, DTYPE_t span_idx):
-    return popcount(spans[0].posns[span_idx])
+    return popcountll(spans[0].posns[span_idx])
 
 
 cdef bint _do_spans_overlap(ActiveSpans* spans_lhs, DTYPE_t span_idx_lhs,
@@ -232,7 +233,7 @@ cdef _span_freqs(DTYPE_t[:] posns,      # Flattened all terms in one array
                 payload_base = ((term & payload_msb_mask) >> lsb_bits) * lsb_bits
                 term &= payload_mask
                 curr_term_mask = 0x1 << term_ord
-                sum_popcount[term_ord] += popcount(posns[curr_idx[term_ord]] & payload_mask)
+                sum_popcount[term_ord] += popcountll(posns[curr_idx[term_ord]] & payload_mask)
 
                 # Consume every position into every possible span
                 while term != 0:


### PR DESCRIPTION
Installing searcharray in Visual Studio Code on MS Windows fails because the MSVC compiler does not support the following GCC/Clang-specific compiler intrinsics: __builtin_popcountll, __builtin_ctzll, __builtin_clzll

The pull request solves the issue by conditionally replacing __builtin_popcountll, __builtin_ctzll, __builtin_clzll with MSVC equivalents in popcount.pyx, roaringish_ops.pyx and spans.pyx

It has been tested both on MS Windows 11 and WSL:Ubuntu-24.04